### PR TITLE
add umlaut handling to channel icon examples

### DIFF
--- a/docs/webui/config_general.md
+++ b/docs/webui/config_general.md
@@ -100,7 +100,7 @@ highlight/reflection effect).
     
 Placeholder | Function
 :----------:| --------
-**%C**      | The transliterated channel name in ASCII (safe characters, no spaces, etc. - so `Das Erste HD` will be `Das_Erste_HD`)
+**%C**      | The transliterated channel name in ASCII (safe characters, no spaces, etc. - so `Das Erste HD` will be `Das_Erste_HD`, but `WDR Köln` will be `WDR_Koln`)
 **%c**      | The channel name (URL encoded ASCII)
 
 Example: `file:///tmp/icons/%C.png` or `http://example.com/%c.png`


### PR DESCRIPTION
The change from a german umlaut ö to the base form o is a little bit suprising.
