### PR TITLE
Update icon path placeholder documentation so it reflects actual behaviour

### DIFF
--- a/docs/webui/config_general.md
+++ b/docs/webui/config_general.md
@@ -100,7 +100,7 @@ highlight/reflection effect).
     
 Placeholder | Function
 :----------:| --------
-**%C**      | The transliterated channel name in ASCII (safe characters, no spaces, etc. - so `Das Erste HD` will be `Das_Erste_HD`, but `WDR Köln` will be `WDR_Koln`)
+**%C**      | The transliterated channel name in ASCII (safe characters, so `WDR Köln` will be `WDR Koln`). Spaces will be transliterated as is, so check that your filesystem can manage spaces in filenames.
 **%c**      | The channel name (URL encoded ASCII)
 
 Example: `file:///tmp/icons/%C.png` or `http://example.com/%c.png`


### PR DESCRIPTION
Documentation stated that %C placeholder in channel icon path replaced spaces with underscores, which doesn't happen anymore in current version. Updated %C placeholder description to reflect actual behaviour.